### PR TITLE
Updated to Revive v4.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,10 @@ RUN apk --update add \
         php7-phar \
         php7-openssl \
         php7-zlib \
+        php7-zip
     && rm -rf /var/cache/apk/*
 
-RUN wget -qO- https://download.revive-adserver.com/revive-adserver-4.1.4.tar.gz | tar xz --strip 1 \
+RUN wget -qO- https://download.revive-adserver.com/revive-adserver-4.2.1.tar.gz | tar xz --strip 1 \
     && chown -R nobody:nobody . \
     && rm -rf /var/cache/apk/*
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 # README #
 
-Revive AdServer docker image based on Alpine Linux with nginx, php7-fpm and Revive adserver 4.1.4
+Revive AdServer docker image based on Alpine Linux with nginx, php7-fpm and Revive adserver 4.2.1
 
 ### What is this repository for? ###
 
 * Quick summary:
-    Revive AdServer docker image based on Alpine Linux with nginx, php7-fpm and Revive Ad Server 4.1.4
+    Revive AdServer docker image based on Alpine Linux with nginx, php7-fpm and Revive Ad Server 4.2.1
 
 * Version 0.2
 * [Repository Link](https://github.com/krish512/ReviveDockerImage.git)


### PR DESCRIPTION
This just upgrades Revive Adserver to the latest version. Revive now requires php7-zip so I've added that package as a dependency.